### PR TITLE
Melhorias no Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 CC=gcc
+CFLAGS=-O2  # to release compile
+#CFLAGS=-O0 -g  # uncomment to debug
 
 .PHONY: all main clean dist-clean
 
@@ -6,7 +8,7 @@ all: main clean
 
 main: a.out
 a.out: main.o lexer/lexer.o symbolsTable/symbolsTable.o lexer/bufferReader/bufferReader.o
-	$(CC) -o $@ $+
+	$(CC) $(CFLAGS) -o $@ $+
 
 clean:
 	find . -type f -name *.o -delete

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC=gcc
 
-.PHONY: all main clean
+.PHONY: all main clean dist-clean
 
 all: main clean
 
@@ -10,3 +10,6 @@ a.out: main.o lexer/lexer.o symbolsTable/symbolsTable.o lexer/bufferReader/buffe
 
 clean:
 	find . -type f -name *.o -delete
+
+dist-clean: clean
+	rm -rf a.out

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,12 @@
+CC=gcc
+
 .PHONY: all main clean
 
 all: main clean
 
-main: main.o lexer.o symbolsTable.o bufferReader.o
-	gcc -o a.out main.o lexer.o symbolsTable.o bufferReader.o
-
-main.o: main.c
-	gcc -o main.o main.c -c
-
-lexer.o: lexer/lexer.c
-	gcc -o lexer.o lexer/lexer.c -c
-
-symbolsTable.o: symbolsTable/symbolsTable.c
-	gcc -o symbolsTable.o symbolsTable/symbolsTable.c -c
-
-bufferReader.o: lexer/bufferReader/bufferReader.c
-	gcc -o bufferReader.o lexer/bufferReader/bufferReader.c -c
+main: a.out
+a.out: main.o lexer/lexer.o symbolsTable/symbolsTable.o lexer/bufferReader/bufferReader.o
+	$(CC) -o $@ $+
 
 clean:
-	rm -rf *.o
+	find . -type f -name *.o -delete

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: all main clean
+
 all: main clean
 
 main: main.o lexer.o symbolsTable.o bufferReader.o


### PR DESCRIPTION
Fiz algumas melhorias no `Makefile`:

- Configuração dos [phony targets](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html), evitando que um arquivo com o mesmo nome do target evite que o comando seja executado, além de um pequeno ganho de performance, já que o make não irá verificar se o target já existe.
- Utiliza os targets built-in para código em C, aumentando a padronização, como a utilização da variável `CC` para informar o compilador, que pode ser facilmente trocado pelo clang, por exemplo, e redução da quantidade de linhas de configuração.
- Cria o target `dist-clean` para limpar completamente o repositório, normalmente utilizado para gerar um tarball de uma versão do projeto.
- Adiciona flags de compilação: otimiza a compilação para distribuição do binário compilado, ou desativando as otimizações do compilador e adicionando informações extras para facilitar o debug e análises como a feita pelo [valgrind](https://valgrind.org/).